### PR TITLE
Support single connection per destination

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
 
 group = 'com.bigdataboutique.logging.log4j2'
-version = '2.7.1'
+version = '2.8.1'
 
 description = """Log4j2 Elasticsearch appender using the Java JDK HTTP client"""
 

--- a/src/main/java/com/bigdataboutique/logging/JsonLogEvent.java
+++ b/src/main/java/com/bigdataboutique/logging/JsonLogEvent.java
@@ -1,0 +1,31 @@
+package com.bigdataboutique.logging;
+
+import com.bigdataboutique.logging.log4j2.ElasticsearchHttpProvider;
+
+import java.util.HashMap;
+
+public class JsonLogEvent {
+    private final HashMap<String, Object> map = new HashMap<>();
+
+    /**
+     * Create a json log event, with key-value pairs in the format key:value, skipping doubly defined keys
+     * @param fields list of key:value strings to create fields from
+     */
+    public JsonLogEvent(String ... fields) {
+        for (final String field : fields) {
+            String[] f = field.split(":");
+            if (f.length != 2) continue; // skip invalid records
+            map.putIfAbsent(f[0], f[1]);
+        }
+    }
+
+    public JsonLogEvent withMessage(final String message) {
+        map.put("message", message);
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return ElasticsearchHttpProvider.toJsonString(map);
+    }
+}

--- a/src/main/java/com/bigdataboutique/logging/log4j2/ElasticsearchHttpClient.java
+++ b/src/main/java/com/bigdataboutique/logging/log4j2/ElasticsearchHttpClient.java
@@ -88,12 +88,12 @@ public class ElasticsearchHttpClient implements Closeable {
     private boolean clusterAvailable = false;
     private volatile boolean closed;
 
-    public ElasticsearchHttpClient(String url, String index, String type, Map<String, List<String>> applyTags,
-                                   int maxActionsPerBulkRequest, long flushSecs, boolean logResponses)
+    ElasticsearchHttpClient(String url, String index, String type, Map<String, List<String>> applyTags,
+                            int maxActionsPerBulkRequest, long flushSecs, boolean logResponses)
             throws MalformedURLException {
 
         this.clusterUrl = new URL(url);
-        this.bulkUrl = new URL(url + "/_bulk".replace("//_bulk", "/_bulk"));
+        this.bulkUrl = new URL(url + "_bulk");
 
         this.index = index;
         this.type = type;

--- a/src/main/java/com/bigdataboutique/logging/log4j2/ElasticsearchHttpProvider.java
+++ b/src/main/java/com/bigdataboutique/logging/log4j2/ElasticsearchHttpProvider.java
@@ -84,6 +84,10 @@ public class ElasticsearchHttpProvider implements NoSqlProvider<ElasticsearchHtt
             url = "http://localhost:9200";
         }
 
+        if (!url.endsWith("/")) {
+            url += "/";
+        }
+
         if (maxActionsPerBulkRequest < 1) {
             maxActionsPerBulkRequest = 1000;
         }

--- a/src/main/java/com/bigdataboutique/logging/log4j2/ElasticsearchHttpProvider.java
+++ b/src/main/java/com/bigdataboutique/logging/log4j2/ElasticsearchHttpProvider.java
@@ -80,7 +80,7 @@ public class ElasticsearchHttpProvider implements NoSqlProvider<ElasticsearchHtt
 
         if (url == null || url.isEmpty()) {
             // TODO test why it's not working with StrSubtitor
-            url = "http://localhost:9200/_bulk";
+            url = "http://localhost:9200";
         }
 
         if (maxActionsPerBulkRequest < 1) {

--- a/src/main/java/com/bigdataboutique/logging/log4j2/ElasticsearchHttpProvider.java
+++ b/src/main/java/com/bigdataboutique/logging/log4j2/ElasticsearchHttpProvider.java
@@ -15,6 +15,7 @@
  */
 package com.bigdataboutique.logging.log4j2;
 
+import com.bigdataboutique.logging.JsonLogEvent;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
@@ -39,7 +40,7 @@ public class ElasticsearchHttpProvider implements NoSqlProvider<ElasticsearchHtt
     private final String description;
     private final ElasticsearchHttpConnection connection;
 
-    public ElasticsearchHttpProvider(final ElasticsearchHttpConnection connection, final String description) {
+    private ElasticsearchHttpProvider(final ElasticsearchHttpConnection connection, final String description) {
         this.connection = connection;
         this.description = "elasticsearch{ " + description + " }";
         LOGGER.info(description + " initialized");
@@ -140,5 +141,11 @@ public class ElasticsearchHttpProvider implements NoSqlProvider<ElasticsearchHtt
         }
 
         return applyTags;
+    }
+
+    public static String toJsonString(HashMap<String, Object> map) {
+        final StringBuilder sb = new StringBuilder(100);
+        ElasticsearchHttpClient.build(sb, map);
+        return sb.toString();
     }
 }


### PR DESCRIPTION
The current implementation triggers many logging threads each writing in bulks to the (possibly same) Elasticsearch destination. This can lead to quickly depleting Elasticsearch bulk threads and in any case doesn't make good use of the bulk API.

This PR creates a connection pool for Elasticsearch connections, and each provider / logger thread writing to the same Elasticsearch destination (cluster endpoint + index name + type) will reuse the actual connection - making the best use of those resources.